### PR TITLE
分离配置文件与修复mkfile()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.DS_Store
+/vendor/
+/composer.lock
+/*.php

--- a/Readme.md
+++ b/Readme.md
@@ -196,8 +196,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY')
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -218,8 +218,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -239,8 +239,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -261,8 +261,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 //fileKeys = "<fileKey1>|<fileKey2>|<fileKey3>";
@@ -284,8 +284,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -306,8 +306,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -328,8 +328,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -350,8 +350,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -371,8 +371,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\MgrAuth;
 use Wcs\Config;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new FileManager($auth);
@@ -505,8 +505,8 @@ $separate = 0;
 
 $fops = '';
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fops($auth, $bucket);
@@ -550,8 +550,8 @@ $prefix = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=fetchURL/'.$fetchURL.'/bucket/'.$bucket.'/key/'.$key.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL).'&force='.$force.'&separate='.$separate;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fmgr($auth, $notifyURL, $force, $separate);
@@ -580,8 +580,8 @@ $prefix = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=resource/'.$resource.'/bucket/'.$bucket.'/key/'.$key.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL).'&force='.$force.'&separate='.$separate;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fmgr($auth, $notifyURL, $force, $separate);
@@ -610,8 +610,8 @@ $prefix = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=resource/'.$resource.'/bucket/'.$bucket.'/key/'.$key.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL).'&force='.$force.'&separate='.$separate;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fmgr($auth, $notifyURL, $force, $separate);
@@ -638,8 +638,8 @@ $key = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=bucket/'.$bucket.'/key/'.$key.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL).'&force='.$force.'&separate='.$separate;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fmgr($auth, $notifyURL, $force, $separate);
@@ -667,8 +667,8 @@ $output = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=bucket/'.$bucket.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL).'&force='.$force.'&separate='.$separate;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fmgr($auth, $notifyURL, $force, $separate);
@@ -688,8 +688,8 @@ $notifyURL = '';
 $force = 0;
 $separate  = 0;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fmgr($auth, $notifyURL, $force, $separate);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wangsucs/wcs-sdk-php",
+    "name": "cloudycity/wcs-sdk-php",
     "description": "wcs sdk for php",
     "keywords": ["wcs", "storage", "sdk", "php", "cloud"],
     "homepage": "https://wcs.chinanetcenter.com/document/Guide",

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,6 @@
     },
     "autoload": {
         "psr-4": {"Wcs\\": "src/Wcs"}
-    }
+    },
+    "license": "MIT"
 }

--- a/example/Fmgr/fmgr_compress.php
+++ b/example/Fmgr/fmgr_compress.php
@@ -25,8 +25,8 @@ if ($keys) {
     $fops = 'fops=bucket/'.$bucket.'/keys/'.$keys.'/keylist/'.$keyList.'/saveas/'.$targetSource;
 }
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/Fmgr/fmgr_copy.php
+++ b/example/Fmgr/fmgr_copy.php
@@ -21,8 +21,8 @@ $prefix = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=resource/'.$resource.'/bucket/'.$bucket.'/key/'.$key.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL);
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/Fmgr/fmgr_delete.php
+++ b/example/Fmgr/fmgr_delete.php
@@ -18,8 +18,8 @@ $key = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=bucket/'.$bucket.'/key/'.$key.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL);
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/Fmgr/fmgr_deletePrefix.php
+++ b/example/Fmgr/fmgr_deletePrefix.php
@@ -20,8 +20,8 @@ $output = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=bucket/'.$bucket.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL);
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/Fmgr/fmgr_fetch.php
+++ b/example/Fmgr/fmgr_fetch.php
@@ -21,8 +21,8 @@ $prefix = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=fetchURL/'.$fetchURL.'/bucket/'.$bucket.'/key/'.$key.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL);
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/Fmgr/fmgr_move.php
+++ b/example/Fmgr/fmgr_move.php
@@ -20,8 +20,8 @@ $prefix = Utils::url_safe_base64_encode('<input key>');
 
 $fops = 'fops=resource/'.$resource.'/bucket/'.$bucket.'/key/'.$key.'/prefix/'.$prefix.'&notifyURL='.Utils::url_safe_base64_encode($notifyURL);
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $client = new Fmgr($auth, $notifyURL, $force, $separate);

--- a/example/PersistentFops/persistent_fops.php
+++ b/example/PersistentFops/persistent_fops.php
@@ -13,8 +13,8 @@ $notifyURL = 'http://callback-test.wcs.biz.matocloud.com:8088/notifyUrl';
 $force = 0;
 $separate = 0;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 $auth = new MgrAuth($ak, $sk);
 
 $fops = 'vframe/jpg/offset/10/w/1000/h/1000|saveas/bGFpaHktdGVzdDp2ZnJhbWUtdGVzdC0yNy5qcGc=';

--- a/example/SrcManage/avinfo.php
+++ b/example/SrcManage/avinfo.php
@@ -32,8 +32,8 @@ print("host:: \t$key\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/avinfo2.php
+++ b/example/SrcManage/avinfo2.php
@@ -32,8 +32,8 @@ print("host:: \t$key\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/bucket_list.php
+++ b/example/SrcManage/bucket_list.php
@@ -4,8 +4,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\Config;
 use Wcs\MgrAuth;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/bucket_stat.php
+++ b/example/SrcManage/bucket_stat.php
@@ -4,8 +4,8 @@ use Wcs\SrcManage\FileManager;
 use Wcs\Config;
 use Wcs\MgrAuth;
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/file_copy.php
+++ b/example/SrcManage/file_copy.php
@@ -39,8 +39,8 @@ print("keyDst: \t$keyDst\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/file_delete.php
+++ b/example/SrcManage/file_delete.php
@@ -32,8 +32,8 @@ print("fileKey: \t$fileKey\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/file_list.php
+++ b/example/SrcManage/file_list.php
@@ -43,8 +43,8 @@ print("endTime: \t$marker\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/file_move.php
+++ b/example/SrcManage/file_move.php
@@ -38,8 +38,8 @@ print("bucketDst: \t$bucketDst\n");
 print("keyDst: \t$keyDst\n");
 
 print("\n");
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/file_stat.php
+++ b/example/SrcManage/file_stat.php
@@ -32,8 +32,8 @@ print("fileKey: \t$fileKey\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/SrcManage/updateMirrorSrc.php
+++ b/example/SrcManage/updateMirrorSrc.php
@@ -33,8 +33,8 @@ print("fileKeys: \t$fileKeys\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/example/Upload/file_upload_callback.php
+++ b/example/Upload/file_upload_callback.php
@@ -41,7 +41,7 @@ print("callbackBody: \t$callbackBody\n");
 
 print("\n");
 $pp = new PutPolicy();
-$pp->overwrite = Config::WCS_OVERWRITE;
+$pp->overwrite = Config::get('WCS_OVERWRITE');
 if ($fileKey == null || $fileKey === '') {
     $pp->scope = $bucketName;
 } else {

--- a/example/Upload/file_upload_detect.php
+++ b/example/Upload/file_upload_detect.php
@@ -38,7 +38,7 @@ print("contentdetect: \t$contentdetect\n");
 print("\n");
 
 $pp = new PutPolicy();
-$pp->overwrite = Config::WCS_OVERWRITE;
+$pp->overwrite = Config::get('WCS_OVERWRITE');
 if ($fileKey == null || $fileKey == '') {
     $pp->scope = $bucketName;
 } else {

--- a/example/Upload/file_upload_notify.php
+++ b/example/Upload/file_upload_notify.php
@@ -42,7 +42,7 @@ print("operation: \t$cmd\n");
 print("\n");
 
 $pp = new PutPolicy();
-$pp->overwrite = Config::WCS_OVERWRITE;
+$pp->overwrite = Config::get('WCS_OVERWRITE');
 if ($fileKey == null || $fileKey === '') {
     $pp->scope = $bucketName;
 } else {

--- a/example/Upload/file_upload_resume.php
+++ b/example/Upload/file_upload_resume.php
@@ -39,7 +39,7 @@ print("localFile: \t$localFile\n");
 print("\n");
 
 $pp = new PutPolicy();
-$pp->overwrite = Config::WCS_OVERWRITE;
+$pp->overwrite = Config::get('WCS_OVERWRITE');
 if ($fileKey == null || $fileKey === '') {
     $pp->scope = $bucketName;
 } else {

--- a/example/Upload/file_upload_return.php
+++ b/example/Upload/file_upload_return.php
@@ -39,7 +39,7 @@ print("returnBody: \t$returnBody\n");
 print("\n");
 
 $pp = new PutPolicy();
-$pp->overwrite = Config::WCS_OVERWRITE;
+$pp->overwrite = Config::get('WCS_OVERWRITE');
 if ($fileKey == null || $fileKey === '') {
     $pp->scope = $bucketName;
 } else {

--- a/example/Upload/file_upload_stream.php
+++ b/example/Upload/file_upload_stream.php
@@ -14,7 +14,7 @@ print("stream: \t$stream\n");
 print("\n");
 
 $pp = new PutPolicy();
-$pp->overwrite = Config::WCS_OVERWRITE;
+$pp->overwrite = Config::get('WCS_OVERWRITE');
 if ($fileKey == null || $fileKey == '') {
     $pp->scope = $bucketName;
 } else {

--- a/example/WsLive/wslive_list.php
+++ b/example/WsLive/wslive_list.php
@@ -40,8 +40,8 @@ print("limit: \t$limit\n");
 
 print("\n");
 
-$ak = Config::WCS_ACCESS_KEY;
-$sk = Config::WCS_SECRET_KEY;
+$ak = Config::get('WCS_ACCESS_KEY');
+$sk = Config::get('WCS_SECRET_KEY');
 
 $auth = new MgrAuth($ak, $sk);
 

--- a/src/Wcs/Auth.php
+++ b/src/Wcs/Auth.php
@@ -11,7 +11,7 @@ class Auth
             return $mac;
         }
 
-        return new Mac(Config::WCS_ACCESS_KEY, Config::WCS_SECRET_KEY );
+        return new Mac(Config::get('WCS_ACCESS_KEY'), Config::get('WCS_SECRET_KEY') );
     }
 
     public static function get_token($mac, $data)

--- a/src/Wcs/Config.php
+++ b/src/Wcs/Config.php
@@ -40,7 +40,7 @@ final class Config
     const WCS_CONCURRENCY = 5;
 
     public static function get($key) {
-        return isset($_ENV[$key]) ? $_ENV[$key] : constant("self::$key");
+        return (isset($_ENV[$key]) && $_ENV[$key] !== '') ? $_ENV[$key] : constant("self::$key");
     }
 }
 

--- a/src/Wcs/Config.php
+++ b/src/Wcs/Config.php
@@ -38,5 +38,9 @@ final class Config
 
     //并发请求数目
     const WCS_CONCURRENCY = 5;
+
+    public static function get($key) {
+        return isset($_ENV[$key]) ? $_ENV[$key] : constant("self::$key");
+    }
 }
 

--- a/src/Wcs/Fmgr/Fmgr.php
+++ b/src/Wcs/Fmgr/Fmgr.php
@@ -67,7 +67,7 @@ class Fmgr {
     }
     public function fetch($fops) {
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/fetch";
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/fetch";
         $signingStr = "/fmgr/fetch" . "\n";
         $content = $this->_addContent($fops);
 
@@ -93,7 +93,7 @@ class Fmgr {
      */
     public function copy($fops) {
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/copy";
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/copy";
         $signingStr = "/fmgr/copy" . "\n";
         $content = $this->_addContent($fops);
         $headers = $this->_genernate_header($url, $content);
@@ -115,7 +115,7 @@ class Fmgr {
      */
     public function move($fops) {
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/move";
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/move";
         $signingStr = "/fmgr/move" . "\n";
         $content = $this->_addContent($fops);
         $headers = $this->_genernate_header($url, $content);
@@ -135,7 +135,7 @@ class Fmgr {
      */
     public function delete($fops) {
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/delete";
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/delete";
         $signingStr = "/fmgr/delete" . "\n";
         $content = $this->_addContent($fops);
         $headers = $this->_genernate_header($url, $content);
@@ -156,7 +156,7 @@ class Fmgr {
      */
     public function deleteM3u8($fops) {
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/deletem3u8";
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/deletem3u8";
         $signingStr = "/fmgr/deletem3u8" . "\n";
         $content = $this->_addContent($fops);
         $headers = $this->_genernate_header($url, $content);
@@ -176,7 +176,7 @@ class Fmgr {
      * @return mixed
      */
     public function deletePrefix($fops) {
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/deletePrefix";
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/deletePrefix";
         $signingStr = "/fmgr/deletePrefix" . "\n";
         $content = $this->_addContent($fops);
         $headers = $this->_genernate_header($url, $content);
@@ -196,7 +196,7 @@ class Fmgr {
      * @return mixed
      */
     public function compress($fops) {
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/compress";
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/compress";
         $signingStr = "/fmgr/compress" . "\n";
         $content = $this->_addContent($fops);
         $headers = $this->_genernate_header($url, $content);
@@ -211,7 +211,7 @@ class Fmgr {
      * @return mixed
      */
     public function status($persistentId) {
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/fmgr/status?persistentId=" . $persistentId;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/fmgr/status?persistentId=" . $persistentId;
         $resp = Utils::http_get($url, null);
 
         return $resp;

--- a/src/Wcs/Http/PutPolicy.php
+++ b/src/Wcs/Http/PutPolicy.php
@@ -104,7 +104,7 @@ final class PutPolicy
         $policy = array('scope' => $this->scope);
 
         if (empty($this->deadline)) {
-            $this->deadline = round(1000 * (microtime(true) + Config::WCS_TOKEN_DEADLINE), 0);
+            $this->deadline = round(1000 * (microtime(true) + Config::get('WCS_TOKEN_DEADLINE')), 0);
         }
         $policy['deadline'] = $this->deadline;
 
@@ -162,8 +162,8 @@ final class PutPolicy
     public function get_token() {
         $ppString = $this->to_string();
         $ppString = Utils::url_safe_base64_encode($ppString);
-        $ak = Config::WCS_ACCESS_KEY;
-        $sk = Config::WCS_SECRET_KEY;
+        $ak = Config::get('WCS_ACCESS_KEY');
+        $sk = Config::get('WCS_SECRET_KEY');
         $sign = hash_hmac('sha1', $ppString, $sk, false);
         return $ak.':'.Utils::url_safe_base64_encode($sign).':'.$ppString;
         #return \Wcs\get_token_with_data($config, $ppString);

--- a/src/Wcs/PersistentFops/Fops.php
+++ b/src/Wcs/PersistentFops/Fops.php
@@ -33,7 +33,7 @@ class Fops {
      * @return mixed
      */
     public function exec($fops, $key, $notifyURL=null, $force=0, $separate=0) {
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . '/fops';
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . '/fops';
         $encodebucket = Utils::url_safe_base64_encode(($this->bucket));
         $body = 'bucket='.$encodebucket;
         $body .= '&key=' . Utils::url_safe_base64_encode($key);
@@ -55,7 +55,7 @@ class Fops {
      * @return mixed
      */
     public static function status($persistentId) {
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . '/status/get/prefop?persistentId=' . $persistentId;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . '/status/get/prefop?persistentId=' . $persistentId;
         $resp = Utils::http_get($url, null);
 
         return $resp;

--- a/src/Wcs/SrcManage/FileManager.php
+++ b/src/Wcs/SrcManage/FileManager.php
@@ -33,7 +33,7 @@ class FileManager
      */
     public function bucketsList()
     {
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . '/bucket/list';
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . '/bucket/list';
         $headers = $this->_genernate_header($url);
 
         return $this->_get($url, $headers);
@@ -68,7 +68,7 @@ class FileManager
             $path.= "&storageType=$storageType";
         }
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . $path;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . $path;
 
         $headers = $this->_genernate_header($url);
 
@@ -81,7 +81,7 @@ class FileManager
         $paramDst = $bucketDst . ":" . $keyDst;
         $paramDst = Utils::url_safe_base64_encode($paramDst);
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/move/" . $paramSrc . "/" . $paramDst;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/move/" . $paramSrc . "/" . $paramDst;
 
         $headers = $this->_genernate_header($url);
 
@@ -105,7 +105,7 @@ class FileManager
         $paramDst = $bucketDst . ":" . $keyDst;
         $paramDst = Utils::url_safe_base64_encode($paramDst);
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . "/copy/" . $paramSrc . "/" . $paramDst;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . "/copy/" . $paramSrc . "/" . $paramDst;
         $headers = $this->_genernate_header($url);
 
         $resp = $this->_post($url, $headers);
@@ -125,7 +125,7 @@ class FileManager
         $entry = $bucketName . ':' . $fileKey;
         $encodedEntry = Utils::url_safe_base64_encode($entry);
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . '/delete/' . $encodedEntry;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . '/delete/' . $encodedEntry;
         $headers = $this->_genernate_header($url);
 
         return $this->_post($url, $headers);
@@ -144,7 +144,7 @@ class FileManager
         $encodedEntry = Utils::url_safe_base64_encode($entry);
 
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . '/stat/' . $encodedEntry;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . '/stat/' . $encodedEntry;
         $headers = $this->_genernate_header($url);
 
         return $this->_get($url, $headers);
@@ -162,7 +162,7 @@ class FileManager
         $encodekey = Utils::url_safe_base64_encode($fileKey);
         $body = 'bucket='.$encodebucket.'&'.'key='.$encodekey.'&'.'deadline='.$deadline;
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL).'/setdeadline';
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')).'/setdeadline';
         $headers = $this->_genernate_header($url, $body);
         return $this->_post($url, $headers, $body);
     }
@@ -200,7 +200,7 @@ class FileManager
             $path .= "&marker=$marker";
         }
 
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . $path;
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . $path;
         $headers = $this->_genernate_header($url);
         $resp = $this->_get($url, $headers);
         return $resp;
@@ -211,7 +211,7 @@ class FileManager
      * @param $fileKeys
      */
     public function updateMirrorSrc($bucket, $fileKeys) {
-        $url = Utils::parse_url(Config::WCS_MGR_URL) . '/prefetch/';
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')) . '/prefetch/';
         $separator = "|";
         $files = explode($separator, $fileKeys);
         $param = $bucket.":";

--- a/src/Wcs/Upload/ResumeUploader.php
+++ b/src/Wcs/Upload/ResumeUploader.php
@@ -8,7 +8,7 @@ use Wcs\Utils;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Promise;
 
@@ -272,7 +272,7 @@ class ResumeUploader
                    $this->mkblkResume($response->getBody(), $index);
                 }
             },
-            'rejected' => function (RequestException $e, $index) {
+            'rejected' => function (TransferException $e, $index) {
                 if ($e->hasResponse() == false) {
                     fwrite($this->rcdLogHandle, date('Y-m-d H:i:s') . " " . "请求超时！" . "\n");
 

--- a/src/Wcs/Upload/ResumeUploader.php
+++ b/src/Wcs/Upload/ResumeUploader.php
@@ -57,9 +57,9 @@ class ResumeUploader
         $mimeType = null
     ) {
 
-        $this->blockSize = Config::WCS_BLOCK_SIZE;
-        $this->chunkSize = Config::WCS_CHUNK_SIZE;
-        $this->countForRetry = Config::WCS_COUNT_FOR_RETRY;
+        $this->blockSize = Config::get('WCS_BLOCK_SIZE');
+        $this->chunkSize = Config::get('WCS_CHUNK_SIZE');
+        $this->countForRetry = Config::get('WCS_COUNT_FOR_RETRY');
         $this->blockNumOfUploaded = 0;
         $this->chunkNumOfUploaded = 0;
         $this->ctxListForMkfile = array();
@@ -105,9 +105,9 @@ class ResumeUploader
         $this->localFile = $localFile;
 
         //记录文件后缀.rcd, WCS_RECORD_URL 为记录文件的路径，默认是上传文件当前路径
-        $this->recordFile = Config::WCS_RECORD_URL . '.' . basename($localFile) . '.rcd';
+        $this->recordFile = Config::get('WCS_RECORD_URL') . '.' . basename($localFile) . '.rcd';
         //日志文件
-        $this->recordLog = Config::WCS_RECORD_URL . '.' . basename($localFile) . '.log';
+        $this->recordLog = Config::get('WCS_RECORD_URL') . '.' . basename($localFile) . '.log';
         if(!file_exists($this->localFile)) {
             die("ERROR: {$this->localFile}文件不存在！");
         }
@@ -190,7 +190,7 @@ class ResumeUploader
         //片大小必须是块大小的整数倍
         $blockNum = ceil($this->sizeOfFile / ($this->blockSize));
 
-        $client = new Client(['timeout' => Config::WCS_TIMEOUT,'User-Agent' =>Utils::get_user_agent()]);
+        $client = new Client(['timeout' => Config::get('WCS_TIMEOUT'),'User-Agent' =>Utils::get_user_agent()]);
 
         $requests = function ($blockNum) {
 
@@ -227,7 +227,7 @@ class ResumeUploader
 
                 $chunkNum = ceil(($curBlockSize) / ($this->chunkSize));
 
-                $url = Utils::parse_url(Config::WCS_PUT_URL) . '/mkblk/' . $curBlockSize . '/' . $curBlockNum;
+                $url = Utils::parse_url(Config::get('WCS_PUT_URL')) . '/mkblk/' . $curBlockSize . '/' . $curBlockNum;
                 //mkblk
                 //如果当前文件剩余内容小于chunkSize,只会读取到EOF
                 //定位到文件上次中断的位置
@@ -417,7 +417,7 @@ class ResumeUploader
      * @return Wcs\Http\Response
      */
     function mkblk($curBlockSize, $curBlockNum, $token, $nextChunk) {
-        $url = Utils::parse_url(Config::WCS_PUT_URL) . '/mkblk/' . $curBlockSize . '/' . $curBlockNum;
+        $url = Utils::parse_url(Config::get('WCS_PUT_URL')) . '/mkblk/' . $curBlockSize . '/' . $curBlockNum;
         $mimeType = null;
 
         $httpHeaders = array(
@@ -441,7 +441,7 @@ class ResumeUploader
      * @return Wcs\Http\Response
      */
     function  bput($ctx, $nextChunkOffset, $token, $nextChunk) {
-        $url = Utils::parse_url(Config::WCS_PUT_URL) . '/bput/' . $ctx . '/' . $nextChunkOffset;
+        $url = Utils::parse_url(Config::get('WCS_PUT_URL')) . '/bput/' . $ctx . '/' . $nextChunkOffset;
         $mimeType = null;
 
         $httpHeaders = array(
@@ -463,7 +463,7 @@ class ResumeUploader
      * @return Wcs\Http\Response
      */
     function mkfile($token) {
-        $url = Utils::parse_url(Config::WCS_PUT_URL) . '/mkfile/' . $this->sizeOfFile . '/';
+        $url = Utils::parse_url(Config::get('WCS_PUT_URL')) . '/mkfile/' . $this->sizeOfFile . '/';
 
         if($this->userParam !== null) {
             $url .= $this->userParam.'/';

--- a/src/Wcs/Upload/ResumeUploader.php
+++ b/src/Wcs/Upload/ResumeUploader.php
@@ -485,7 +485,7 @@ class ResumeUploader
         for($i = 0; $i < $blockNum; $i ++) {
             array_push($this->hashTable['info']['ctxList'], $this->hashTable[$i]['latestCtx']);
         }
-        $fields = implode($this->hashTable['info']['ctxList'], ",");
+        $fields = implode(',', $this->hashTable['info']['ctxList']);
         $resp = Utils::http_post($url, $httpHeaders, $fields);
 
         return $resp;

--- a/src/Wcs/Upload/StreamUploader.php
+++ b/src/Wcs/Upload/StreamUploader.php
@@ -43,16 +43,16 @@ class StreamUploader
         if(!isset($content)||strlen($content)==0) {
             die("ERROR: {$Stream}流地址无效！"."\n");
         }
-        if(!is_dir(Config::WCS_RAM_URL))
+        if(!is_dir(Config::get('WCS_RAM_URL')))
         {
             die("ERROR: 虚拟内存目录不存在！");
         }
-        $filename = Config::WCS_RAM_URL."steam";
+        $filename = Config::get('WCS_RAM_URL')."steam";
 
         $fp = fopen($filename, "w+b");
         fwrite($fp, $content);
         rewind($fp);
-        $url = Utils::parse_url(Config::WCS_PUT_URL) . '/file/upload';
+        $url = Utils::parse_url(Config::get('WCS_PUT_URL')) . '/file/upload';
 
         $mimeType = null;
         $fields = array(

--- a/src/Wcs/Upload/Uploader.php
+++ b/src/Wcs/Upload/Uploader.php
@@ -47,7 +47,7 @@ class Uploader
         if(!file_exists($localFile)) {
             die("ERROR: {$localFile}文件不存在！");
         }
-        $url = Utils::parse_url(Config::WCS_PUT_URL) . '/file/upload';
+        $url = Utils::parse_url(Config::get('WCS_PUT_URL')) . '/file/upload';
 
         $token = $this->token;
 

--- a/src/Wcs/Utils.php
+++ b/src/Wcs/Utils.php
@@ -54,7 +54,7 @@ class Utils
 
     public static function get_user_agent()
     {
-        $sdkInfo = "WCS PHP SDK /" . Config::WCS_SDK_VER . " (http://wcs.chinanetcenter.com/)";
+        $sdkInfo = "WCS PHP SDK /" . Config::get('WCS_SDK_VER') . " (http://wcs.chinanetcenter.com/)";
 
         $systemInfo = php_uname("s");
         $machineInfo = php_uname("m");
@@ -78,7 +78,7 @@ class Utils
             CURLOPT_HEADER => true,
             CURLOPT_NOBODY => false,
             CURLOPT_URL => $url,
-            CURLOPT_TIMEOUT => Config::WCS_TIMEOUT
+            CURLOPT_TIMEOUT => Config::get('WCS_TIMEOUT')
         );
 
         if($opt) {
@@ -147,8 +147,8 @@ class Utils
             CURLOPT_NOBODY => false,
             CURLOPT_CUSTOMREQUEST => 'POST',
             CURLOPT_URL => $url,
-            CURLOPT_TIMEOUT => Config::WCS_TIMEOUT,
-            CURLOPT_CONNECTTIMEOUT => Config::WCS_CONNECTTIMEOUT,
+            CURLOPT_TIMEOUT => Config::get('WCS_TIMEOUT'),
+            CURLOPT_CONNECTTIMEOUT => Config::get('WCS_CONNECTTIMEOUT'),
         );
 
         if($opt) {
@@ -208,10 +208,10 @@ class Utils
     {
         $HTTP_PREFIX = 'http://';
 
-        if (self::str_start_with(Config::WCS_GET_URL, $HTTP_PREFIX)) {
-            $baseUrl = $HTTP_PREFIX . $bucketName . '.' . substr(Config::WCS_GET_URL, strlen($HTTP_PREFIX));
+        if (self::str_start_with(Config::get('WCS_GET_URL'), $HTTP_PREFIX)) {
+            $baseUrl = $HTTP_PREFIX . $bucketName . '.' . substr(Config::get('WCS_GET_URL'), strlen($HTTP_PREFIX));
         } else {
-            $baseUrl = $bucketName . '.' . Config::WCS_GET_URL;
+            $baseUrl = $bucketName . '.' . Config::get('WCS_GET_URL');
         }
 
             $baseUrl .= '/' . $fileName;

--- a/src/Wcs/Wslive/WsLive.php
+++ b/src/Wcs/Wslive/WsLive.php
@@ -20,7 +20,7 @@ class WsLive
     }
     public function wslive_list($channelname, $startTime, $endTime, $bucket, $start=null, $limit=null)
     {
-        $url = Utils::parse_url(Config::WCS_MGR_URL).'/wslive/list';
+        $url = Utils::parse_url(Config::get('WCS_MGR_URL')).'/wslive/list';
         $query = "channelname=".$channelname."&startTime=".$startTime."&endTime=".$endTime."&bucket=".$bucket;
         if($start)
         {


### PR DESCRIPTION
1. 实现配置文件与源码分离，Config类的常量作为默认配置，自定义配置在$_ENV中配置。
2. 修复ResumeUploader::mkfile()中的implode()的参数顺序。